### PR TITLE
Added PHP 7.2 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
     - php: 7.0
     - php: 7.1
+    - php: 7.2
     - php: nightly
     - php: hhvm
       sudo: required

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following versions of PHP are supported.
 * PHP 5.6
 * PHP 7.0
 * PHP 7.1
+* PHP 7.2
 * HHVM
 
 ## Installation


### PR DESCRIPTION
This libary does not currently list PHP 7.2 as supported, and there are no associated Travis tests. Currently Travis is running PHP <= 7.1 as well as  `nightly`, which is now PHP 7.3. 

I've added PHP 7.2 as a discrete test case on Travis, and added PHP 7.2 to the supported version in the README.

All tests are passing under PHP 7.2.4 locally and on Travis.