### PR TITLE
Remove version sicking

### DIFF
--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -28,7 +28,7 @@ class Discord extends AbstractProvider
      *
      * @var string
      */
-    public $apiDomain = 'https://discord.com/api/v6';
+    public $apiDomain = 'https://discord.com/api';
 
     /**
      * Get authorization URL to begin OAuth flow


### PR DESCRIPTION
Sticking with v6 is a bad idea, v6 might be deprecated soon, I recommend just going without version in endpoint url.