### PR TITLE
Fix authorization and access token tests

### DIFF
--- a/test/src/Provider/DiscordTest.php
+++ b/test/src/Provider/DiscordTest.php
@@ -54,7 +54,7 @@ class DiscordTest extends \PHPUnit\Framework\TestCase
         $url = $this->provider->getAuthorizationUrl();
         $uri = parse_url($url);
 
-        $this->assertEquals('/api/oauth2/authorize', $uri['path']);
+        $this->assertEquals('/api/v9/oauth2/authorize', $uri['path']);
     }
 
     public function testGetBaseAccessTokenUrl()
@@ -64,7 +64,7 @@ class DiscordTest extends \PHPUnit\Framework\TestCase
         $url = $this->provider->getBaseAccessTokenUrl($params);
         $uri = parse_url($url);
 
-        $this->assertEquals('/api/oauth2/token', $uri['path']);
+        $this->assertEquals('/api/v9/oauth2/token', $uri['path']);
     }
 
     public function testGetAccessToken()


### PR DESCRIPTION
This fixes failing tests after merging #39 which did not appropriately update the authorization and access token URL tests in the same way as #33 did.