### PR TITLE
Specify PHP 8.x versions as supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
+    - php: 8.1
+    - php: 8.2
     - php: nightly
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The following versions of PHP are supported.
 * PHP 7.2
 * PHP 7.3
 * PHP 7.4
+* PHP 8.0
+* PHP 8.1
+* PHP 8.2
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
         "discord"
     ],
     "require": {
+        "php": "^7.2|^8.0",
+        "ext-json": "*",
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 8.x versions work fine without any issues. I have also added the PHP version requirement to the Composer file.

In my opinion, it should be a part of it as this makes the supported versions clear both for the user and the developer. And thanks to this, we can safely use features of PHP 7.2 and later.