### PR TITLE
Revisit default scopes

### DIFF
--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -90,9 +90,6 @@ class Discord extends AbstractProvider
         return [
             'identify',
             'email',
-            'connections',
-            'guilds',
-            'guilds.join'
         ];
     }
 


### PR DESCRIPTION
The default scopes were flawed because many of them are not vital for providing the basic user interface:

> This should not be a complete list of all scopes, but the minimum required for the provider user interface!

Whether the email scope should be included as well is for discussion. Nevertheless, since `DiscordResourceOwner` provides a getter for the email address, I have included it, too.

This is a **breaking change** because if the developer does not specify the scopes, their existing authorization grants will become invalid. As a result of this, existing users will have to reauthorize (due to the change of scopes). On the other hand, starting with this library will be easier for new developers as, most of the time, different scopes are unnecessary.