### PR TITLE
Update OAuth2 base authorization URL

### DIFF
--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -24,7 +24,14 @@ class Discord extends AbstractProvider
     use BearerAuthorizationTrait;
 
     /**
-     * API Domain
+     * Default host
+     *
+     * @var string
+     */
+    public $host = 'https://discord.com';
+
+    /**
+     * API domain
      *
      * @var string
      */
@@ -37,7 +44,7 @@ class Discord extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return $this->apiDomain.'/oauth2/authorize';
+        return $this->host.'/oauth2/authorize';
     }
 
     /**

--- a/test/src/Provider/DiscordTest.php
+++ b/test/src/Provider/DiscordTest.php
@@ -54,7 +54,7 @@ class DiscordTest extends \PHPUnit\Framework\TestCase
         $url = $this->provider->getAuthorizationUrl();
         $uri = parse_url($url);
 
-        $this->assertEquals('/api/v9/oauth2/authorize', $uri['path']);
+        $this->assertEquals('/oauth2/authorize', $uri['path']);
     }
 
     public function testGetBaseAccessTokenUrl()

--- a/test/src/Provider/DiscordTest.php
+++ b/test/src/Provider/DiscordTest.php
@@ -54,7 +54,7 @@ class DiscordTest extends \PHPUnit\Framework\TestCase
         $url = $this->provider->getAuthorizationUrl();
         $uri = parse_url($url);
 
-        $this->assertEquals('/api/oauth2/authorize', $uri['path']);
+        $this->assertEquals('/api/v9/oauth2/authorize', $uri['path']);
     }
 
     public function testGetBaseAccessTokenUrl()
@@ -64,7 +64,7 @@ class DiscordTest extends \PHPUnit\Framework\TestCase
         $url = $this->provider->getBaseAccessTokenUrl($params);
         $uri = parse_url($url);
 
-        $this->assertEquals('/api/oauth2/token', $uri['path']);
+        $this->assertEquals('/api/v9/oauth2/token', $uri['path']);
     }
 
     public function testGetAccessToken()


### PR DESCRIPTION
This removes a useless redirect as the OAuth2 authorization is no longer a part of the API.
_See discord/discord-api-docs#5237 for reference._

This pull request also fixes the access token URL test which got broken after merging #39.
This has been fixed in the same way as #33 implemented it.