### PR TITLE
Token revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ if (!isset($_GET['code'])) {
 }
 ```
 
+Keep in mind that this is only a simple example. In your application, you might
+want to modify the scopes to your needs, use a database with persistent storage
+for the token data, or revoke the tokens once they are no longer used.
+
 ### Managing Scopes
 
 When creating your Discord authorization URL in Step 1, you can specify the state and scopes your application may authorize.
@@ -144,6 +148,31 @@ if ($existingAccessToken->hasExpired()) {
     // Purge old access token and store new access token to your data store.
 }
 ```
+
+### Revoking a Token
+
+No longer used tokens should be revoked so the authorization server can clean up
+data associated with that token. This is useful when the end-user logs out or
+uninstalls your application, and it can be achieved by invoking a simple request
+to the authorization server using the refresh token:
+
+```php
+$provider = new \Wohali\OAuth2\Client\Provider\Discord([
+    'clientId' => '{discord-client-id}',
+    'clientSecret' => '{discord-client-secret}',
+]);
+
+/** @var League\OAuth2\Client\Token\AccessTokenInterface $existingAccessToken */
+$existingAccessToken = getAccessTokenFromYourDataStore();
+
+$provider->revokeToken([
+    'token' => $existingAccessToken->getRefreshToken(),
+    'token_type_hint' => 'refresh_token',
+]);
+```
+
+Keep in mind that due to the nature of this request, the authorization server
+does not throw any error when a token is (already) invalid.
 
 ### Client Credentials Grant
 

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -163,7 +163,13 @@ class Discord extends AbstractProvider
      */
     protected function getRevokeTokenOptions(string $method, array $params)
     {
-        return $this->optionProvider->getAccessTokenOptions($method, $params);
+        $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
+
+        if ($method === AbstractProvider::METHOD_POST) {
+            $options['body'] = $this->buildQueryString($params);
+        }
+
+        return $options;
     }
 
     /**

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -145,7 +145,7 @@ class Discord extends AbstractProvider
     }
 
     /**
-     * Return the method to use when revoking the access/refresh token
+     * Return the method to use when revoking the access/refresh token.
      *
      * @return string
      */
@@ -155,7 +155,7 @@ class Discord extends AbstractProvider
     }
 
     /**
-     * Build request options used for revoking an access/refresh token
+     * Build request options used for revoking an access/refresh token.
      *
      * @param  string $method
      * @param  array $params
@@ -167,7 +167,7 @@ class Discord extends AbstractProvider
     }
 
     /**
-     * Return a prepared request for revoking an access/refresh token
+     * Return a prepared request for revoking an access/refresh token.
      *
      * @param  array $params
      * @return RequestInterface
@@ -183,18 +183,18 @@ class Discord extends AbstractProvider
     }
 
     /**
-     * Request a token revocation
+     * Request a token revocation.
      *
-     * Revoking an access/refresh token will invalidate it and will clean up
+     * Revoking an access/refresh token will invalidate it and clean up
      * associated data with the underlying authorization grant.
      *
      * Revoking an access token MAY also invalidate the refresh token based on
-     * the same authorization grant. It actually is the current behavior of the
-     * Discord OAuth2 server. However, this behavior is only optional (according
-     * to the section 2.1, RFC7009) and undocumented and may change.
+     * the same authorization grant. Based on the Discord documentation, it is
+     * the current behavior of the OAuth2 server. However, keep in mind that
+     * this behavior is only optional (according to the section 2.1, RFC7009).
      *
-     * On the other hand, revoking a refresh token will immediately invalidate
-     * all access tokens based on the same authorization grant.
+     * Revoking a refresh token will immediately invalidate all access tokens
+     * based on the same authorization grant.
      *
      * @param  array $options Request parameters
      * @return void

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -219,7 +219,18 @@ class Discord extends AbstractProvider
     /**
      * Request a token revocation
      *
-     * @param  array $options
+     * Revoking an access/refresh token will invalidate it and will clean up
+     * associated data with the underlying authorization grant.
+     *
+     * Revoking an access token MAY also invalidate the refresh token based on
+     * the same authorization grant. It actually is the current behavior of the
+     * Discord OAuth2 server. However, this behavior is only optional (according
+     * to the section 2.1, RFC7009) and undocumented and may change.
+     *
+     * On the other hand, revoking a refresh token will immediately invalidate
+     * all access tokens based on the same authorization grant.
+     *
+     * @param  array $options Request parameters
      * @return void
      *
      * @throws IdentityProviderException
@@ -235,48 +246,7 @@ class Discord extends AbstractProvider
         $params = $this->prepareRevokeTokenParameters($params, $options);
         $request = $this->getRevokeTokenRequest($params);
 
-        // The name of the method is misleading, however, this also sends the request
+        // The name is misleading, however, this also sends the request
         $this->getParsedResponse($request);
-    }
-
-    /**
-     * Revoke an access token
-     *
-     * This MAY revoke the refresh token based on the same authorization grant,
-     * too. _Currently, it actually is the behavior of the Discord OAuth2 server._
-     *
-     * However, as this is only an optional behavior (according to the section 2.1,
-     * RFC7009) and it is not properly documented by Discord, it is recommended
-     * to either revoke all tokens manually, or revoke the refresh token only.
-     *
-     * @param  string $accessToken
-     * @return void
-     *
-     * @throws IdentityProviderException
-     * @throws UnexpectedValueException
-     */
-    public function revokeAccessToken(string $accessToken)
-    {
-        $this->revokeToken([
-            'token' => $accessToken,
-            'token_type_hint' => 'access_token',
-        ]);
-    }
-
-    /**
-     * Revoke all tokens based on the same authorization grant by a refresh token
-     *
-     * @param  string $refreshToken
-     * @return void
-     *
-     * @throws IdentityProviderException
-     * @throws UnexpectedValueException
-     */
-    public function revokeRefreshToken(string $refreshToken)
-    {
-        $this->revokeToken([
-            'token' => $refreshToken,
-            'token_type_hint' => 'refresh_token',
-        ]);
     }
 }

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -14,9 +14,13 @@
 namespace Wohali\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use UnexpectedValueException;
 use Wohali\OAuth2\Client\Provider\Exception\DiscordIdentityProviderException;
 
 class Discord extends AbstractProvider
@@ -50,6 +54,16 @@ class Discord extends AbstractProvider
     public function getBaseAccessTokenUrl(array $params)
     {
         return $this->apiDomain.'/oauth2/token';
+    }
+
+    /**
+     * Get revoke token URL to revoke an access/refresh token
+     *
+     * @return string
+     */
+    public function getBaseRevokeTokenUrl()
+    {
+        return $this->apiDomain.'/oauth2/token/revoke';
     }
 
     /**
@@ -116,10 +130,153 @@ class Discord extends AbstractProvider
      *
      * @param array $response
      * @param AccessToken $token
-     * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
+     * @return ResourceOwnerInterface
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
         return new DiscordResourceOwner($response);
+    }
+
+    /**
+     * Return the method to use when revoking the access/refresh token
+     *
+     * @return string
+     */
+    protected function getRevokeTokenMethod()
+    {
+        return self::METHOD_POST;
+    }
+
+    /**
+     * Build request options used for revoking an access/refresh token
+     *
+     * @param  string $method
+     * @param  array $params
+     * @return array
+     */
+    protected function getRevokeTokenOptions(string $method, array $params)
+    {
+        return $this->optionProvider->getAccessTokenOptions($method, $params);
+    }
+
+    /**
+     * Return a prepared request for revoking an access/refresh token
+     *
+     * @param  array $params
+     * @return RequestInterface
+     */
+    protected function getRevokeTokenRequest(array $params)
+    {
+        $method = $this->getRevokeTokenMethod();
+        $url = $this->getBaseRevokeTokenUrl();
+
+        $options = $this->getRevokeTokenOptions($method, $params);
+
+        return $this->getRequest($method, $url, $options);
+    }
+
+    /**
+     * Retrieve the OAuth Token Type Hint registry
+     *
+     * @return array
+     */
+    protected function getRevokeTokenTypes()
+    {
+        return ['access_token', 'refresh_token'];
+    }
+
+    /**
+     * Prepare request parameters for the token revocation request
+     *
+     * This makes sure that fields contain the correct value
+     *
+     * @param  array $defaults
+     * @param  array $options
+     * @return array
+     *
+     * @throws UnexpectedValueException
+     */
+    protected function prepareRevokeTokenParameters(array $defaults, array $options)
+    {
+        $provided = array_merge($defaults, $options);
+
+        // List of all known token types that can be revoked
+        $tokenTypes = $this->getRevokeTokenTypes();
+
+        if (isset($provided['token_type_hint']) && !in_array($provided['token_type_hint'], $tokenTypes)) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid token type hint "%s". The possible options are: %s',
+                    $provided['token_type_hint'],
+                    implode(', ', $tokenTypes)
+                )
+            );
+        }
+
+        return $provided;
+    }
+
+    /**
+     * Request a token revocation
+     *
+     * @param  array $options
+     * @return void
+     *
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
+     */
+    public function revokeToken(array $options)
+    {
+        $params = [
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+        ];
+
+        $params = $this->prepareRevokeTokenParameters($params, $options);
+        $request = $this->getRevokeTokenRequest($params);
+
+        // The name of the method is misleading, however, this also sends the request
+        $this->getParsedResponse($request);
+    }
+
+    /**
+     * Revoke an access token
+     *
+     * This MAY revoke the refresh token based on the same authorization grant,
+     * too. _Currently, it actually is the behavior of the Discord OAuth2 server._
+     *
+     * However, as this is only an optional behavior (according to the section 2.1,
+     * RFC7009) and it is not properly documented by Discord, it is recommended
+     * to either revoke all tokens manually, or revoke the refresh token only.
+     *
+     * @param  string $accessToken
+     * @return void
+     *
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
+     */
+    public function revokeAccessToken(string $accessToken)
+    {
+        $this->revokeToken([
+            'token' => $accessToken,
+            'token_type_hint' => 'access_token',
+        ]);
+    }
+
+    /**
+     * Revoke all tokens based on the same authorization grant by a refresh token
+     *
+     * @param  string $refreshToken
+     * @return void
+     *
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
+     */
+    public function revokeRefreshToken(string $refreshToken)
+    {
+        $this->revokeToken([
+            'token' => $refreshToken,
+            'token_type_hint' => 'refresh_token',
+        ]);
     }
 }

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -26,6 +26,7 @@ use Wohali\OAuth2\Client\Provider\Exception\DiscordIdentityProviderException;
 class Discord extends AbstractProvider
 {
     use BearerAuthorizationTrait;
+    use TokenRevocationProviderTrait;
 
     /**
      * API Domain
@@ -173,47 +174,6 @@ class Discord extends AbstractProvider
         $options = $this->getRevokeTokenOptions($method, $params);
 
         return $this->getRequest($method, $url, $options);
-    }
-
-    /**
-     * Retrieve the OAuth Token Type Hint registry
-     *
-     * @return array
-     */
-    protected function getRevokeTokenTypes()
-    {
-        return ['access_token', 'refresh_token'];
-    }
-
-    /**
-     * Prepare request parameters for the token revocation request
-     *
-     * This makes sure that fields contain the correct value
-     *
-     * @param  array $defaults
-     * @param  array $options
-     * @return array
-     *
-     * @throws UnexpectedValueException
-     */
-    protected function prepareRevokeTokenParameters(array $defaults, array $options)
-    {
-        $provided = array_merge($defaults, $options);
-
-        // List of all known token types that can be revoked
-        $tokenTypes = $this->getRevokeTokenTypes();
-
-        if (isset($provided['token_type_hint']) && !in_array($provided['token_type_hint'], $tokenTypes)) {
-            throw new UnexpectedValueException(
-                sprintf(
-                    'Invalid token type hint "%s". The possible options are: %s',
-                    $provided['token_type_hint'],
-                    implode(', ', $tokenTypes)
-                )
-            );
-        }
-
-        return $provided;
     }
 
     /**

--- a/src/Provider/TokenRevocationProviderTrait.php
+++ b/src/Provider/TokenRevocationProviderTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the wohali/oauth2-discord-new library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Joan Touzet <code@atypical.net>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://packagist.org/packages/wohali/oauth2-discord-new Packagist
+ * @link https://github.com/wohali/oauth2-discord-new GitHub
+ */
+
+namespace Wohali\OAuth2\Client\Provider;
+
+use UnexpectedValueException;
+
+trait TokenRevocationProviderTrait
+{
+    /**
+     * Retrieve the OAuth Token Type Hint registry
+     *
+     * @return array
+     */
+    protected function getRevokeTokenTypes()
+    {
+        return ['access_token', 'refresh_token'];
+    }
+
+    /**
+     * Prepare request parameters for the token revocation request
+     *
+     * This makes sure that fields contain the correct value
+     *
+     * @param  array $defaults
+     * @param  array $options
+     * @return array
+     *
+     * @throws UnexpectedValueException
+     */
+    protected function prepareRevokeTokenParameters(array $defaults, array $options)
+    {
+        $provided = array_merge($defaults, $options);
+
+        // List of all known token types that can be revoked
+        $tokenTypes = $this->getRevokeTokenTypes();
+
+        if (isset($provided['token_type_hint']) && !in_array($provided['token_type_hint'], $tokenTypes)) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Invalid token type hint "%s". The possible options are: %s',
+                    $provided['token_type_hint'],
+                    implode(', ', $tokenTypes)
+                )
+            );
+        }
+
+        return $provided;
+    }
+}


### PR DESCRIPTION
This is an implementation of the token revocation based on [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009).

## Introduction

Revoking a token using the OAuth 2.0 Client is a bit more complex. This action is not a part of the traditional [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749) standard, and therefore, contributors of **The League of Extraordinary Packages** refused to provide any interface for it.
_See thephpleague/oauth2-client#479 for more information._

As a result, we are left to implement the token revocation fully. This is, however, a considerable problem in many cases. We obviously cannot break the public API and cannot extend existing interfaces or abstractions. Moreover, the implementation of the base provider does not allow any reasonable abstraction for the token revocation due to everything being based on access tokens only.

This also raises the question of how to properly open the token revocation for an extension.

## Implementation

Considering everything mentioned above, I have kept everything as simple as possible. When you compare my implementation to the access token methods, you will find the connection between them:

- `AbstractProvider::getBaseAccessTokenUrl()` => `Discord::getBaseRevokeTokenUrl()`
- `AbstractProvider::getAccessTokenMethod()` => `Discord::getRevokeTokenMethod()`
- `AbstractProvider::getAccessTokenRequest()` => `Discord::getRevokeTokenRequest()`
- `AbstractProvider::getAccessToken()` => `Discord::revokeToken()`

The method that the user is interested in, `revokeToken()`, has the same interface as `getAccessToken()`. This allows the user to specify any other parameter or override existing options.

I had the idea of creating methods such as `revokeAccessToken()` or `revokeRefreshToken()`. This would, however, not be correct according to [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009). This standard allows the developer to send any token, and the authorization server is supposed to deal with that in the best possible manner.

## Undefined Behavior

Another concern of this whole pull request is the lack of documentation. Except for specifying the URL, the [official documentation](https://discord.com/developers/docs/topics/oauth2) does not describe the token revocation in any way. This raises many questions as the standard has a few recommendations and is sometimes open for interpretation.

### Revocation Request

Let's take a look at [section 2.1. of RFC7009](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1):

>   Depending on the authorization server's revocation policy, the
>   revocation of a particular token may cause the revocation of related
>   tokens and the underlying authorization grant.  If the particular
>   token is a refresh token and the authorization server supports the
>   revocation of access tokens, then the authorization server SHOULD
>   also invalidate all access tokens based on the same authorization
>   grant (see Implementation Note).  If the token passed to the request
>   is an access token, the server MAY revoke the respective refresh
>   token as well.

_Refer to [RFC2119](https://datatracker.ietf.org/doc/html/rfc2119) for the explanation of SHOULD and MAY keywords._

As of right now, sending either a refresh token or an access token invalidates the full authorization grant. This is now also documented in the official Discord documentation (see discord/discord-api-docs#6356 for more details).

### Error Response

Error responses are unclear. Let me quote [section 2.2.1. of RFC7009](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1):

>   If the server responds with HTTP status code 503, the client must
>   assume the token still exists and may retry after a reasonable delay.
>   The server may include a "Retry-After" header in the response to
>   indicate how long the service is expected to be unavailable to the
>   requesting client.

This status code, however, is not discussed anywhere in the Discord documentation. As this rather seems to be a rare error and may occur in the OAuth2 authorization flow, too, I have left it unhandled. Or, well, it is currently handled by `checkResponse()`.

## Sources

When I was implementing this, I went through external sources (other libraries, guides, ...). These are my observations:

- None of the official OAuth 2.0 Client providers implement token revocation
- The [Discord official documentation](https://discord.com/developers/docs/topics/oauth2) provides [an example of revoking a token](https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example)
- An [official guide of the respected Discord.JS library](https://discordjs.guide/oauth2/) does not mention token revocation at all
- The JavaScript [discord-oauth2](https://www.npmjs.com/package/discord-oauth2) library provides a [method for revoking the access token](https://github.com/reboxer/discord-oauth2#revoketokenaccess_token-credentials). However, its documentation is unclear and poor and the method is not fully compatible with [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009) (it does not support `token_type_hint`)
- [Another PHP library](https://github.com/Xwilarg/Discord-OAuth2-PHP) does not support token revocation
- The [original OAuth 2.0 Client for Discord](https://packagist.org/packages/team-reflex/oauth2-discord) does not support token revocation

## Consideration

I mentioned these sources for a reason. Token revocation seems to be an ignored topic in general. Therefore, this implementation is only based on information from the standard and my observations.

This can obviously become a problem. Things might change between versions without notice and cause issues for the users of this library. On the other hand, this must not be a reason why we should ignore this topic. Token revocation is extremely useful as it fully logs out the Discord user and deletes all data connected to the respective authorization grant (e.g., [application metadata](https://discord.com/developers/docs/resources/application-role-connection-metadata)).

-----

All in all, this pull request follows the contributing guidelines of this repository:

- [x] All linters have successfully validated my code
- [x] I have added tests covering all new code
- [x] I have documented this feature in README

This resolves #34.