### PR TITLE
Provide direct support for PHP 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - php: 8.0
     - php: 8.1
     - php: 8.2
+    - php: 8.3
     - php: nightly
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following versions of PHP are supported.
 * PHP 8.0
 * PHP 8.1
 * PHP 8.2
+* PHP 8.3
 
 ## Installation
 


### PR DESCRIPTION
There are no breaking changes with PHP 8.3. Yet, it would be great to directly address that PHP 8.3 is supported and also build against it to really make sure there are no issues.